### PR TITLE
Include Alembic Migration Files in Version Control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ __pycache__/
 .vscode/
 .idea/
 
-# Alembic
-alembic/versions/*.py

--- a/alembic/versions/44011bb3379e_init_schema.py
+++ b/alembic/versions/44011bb3379e_init_schema.py
@@ -1,0 +1,28 @@
+"""init schema
+
+Revision ID: 44011bb3379e
+Revises: 
+Create Date: 2025-09-19 08:17:47.761219
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '44011bb3379e'
+down_revision: Union[str, Sequence[str], None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
- Removed .gitignore entry that excluded migrations/versions
- Added Alembic version files to repository
- Ensured Alembic head revisions are now tracked and visible in logs