### PR TITLE
test(infra): add basic infrastructure tests

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -1,8 +1,10 @@
-from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy import text
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.exc import OperationalError
-from app.core.config import settings
 from app.core.logging_config import logger
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+from app.core.config import settings
 
 Base = declarative_base()
 
@@ -23,3 +25,11 @@ except OperationalError as e:
     raise
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+def get_db() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+

--- a/app/main.py
+++ b/app/main.py
@@ -3,9 +3,11 @@ from .api.monitoring import healthcheck
 from .api import action_submissions, audit_events, decisions, policies, rules
 from app.core.logging_config import setup_logging, logger
 from .core.error_handler import log_exceptions
+from contextlib import asynccontextmanager
 
 setup_logging()
 
+@asynccontextmanager
 async def lifespan(app: FastAPI):
     logger.info("Application is starting up...")
     yield

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pytest
 uliweb-alembic
 structlog
 fastapi
@@ -9,3 +10,4 @@ pydantic
 pydantic-settings
 pyyaml
 python-json-logger
+testcontainers[postgresql]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,60 @@
 import pytest
+from testcontainers.postgres import PostgresContainer
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from alembic import command
+from alembic.config import Config
 from fastapi.testclient import TestClient
-from app.main import app
 
-@pytest.fixture(scope="module")
-def client():
-    with TestClient(app) as c:
-        yield c
+from app.main import app
+from app.db.database import get_db
+
+# --- Postgres Fixture ---
+@pytest.fixture(scope="session")
+def postgres_container():
+    with PostgresContainer("postgres:15") as postgres:
+        yield postgres
+
+
+@pytest.fixture(scope="session")
+def migrated_engine(postgres_container):
+    # Create SQLAlchemy engine
+    engine = create_engine(postgres_container.get_connection_url())
+
+    # Run Alembic migrations against this test DB
+    alembic_cfg = Config("alembic.ini")
+    alembic_cfg.set_main_option("sqlalchemy.url", postgres_container.get_connection_url())
+    command.upgrade(alembic_cfg, "head")
+
+    yield engine
+
+    engine.dispose()
+
+
+@pytest.fixture()
+def db_session(migrated_engine):
+    """Provide a clean database session for each test."""
+    connection = migrated_engine.connect()
+    transaction = connection.begin()
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=connection)
+    session = SessionLocal()
+
+    yield session
+
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    """FastAPI test client that uses the test DB session."""
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            db_session.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()

--- a/tests/schema/test_db.py
+++ b/tests/schema/test_db.py
@@ -1,0 +1,6 @@
+from sqlalchemy import text
+
+
+def test_db_connection(db_session):
+    result = db_session.execute(text("SELECT 1")).scalar()
+    assert result == 1


### PR DESCRIPTION
### What Changed
- Introduced pytest fixtures for Postgres test DB using Testcontainers.
- Added @asynccontextmanager to main.py
- Added database connection test to validate DB session and migrations.